### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an error message

### DIFF
--- a/framework/src/main/java/org/tron/core/services/http/GetBrokerageServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/GetBrokerageServlet.java
@@ -28,8 +28,9 @@ public class GetBrokerageServlet extends RateLimiterServlet {
       response.getWriter().println("{\"brokerage\": " + value + "}");
     } catch (DecoderException | IllegalArgumentException e) {
       try {
+        logger.debug("DecoderException or IllegalArgumentException: {}", e.getMessage());
         response.getWriter()
-            .println("{\"Error\": " + "\"INVALID address, " + e.getMessage() + "\"}");
+            .println("{\"Error\": " + "\"INVALID address\"}");
       } catch (IOException ioe) {
         logger.debug("IOException: {}", ioe.getMessage());
       }


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/java-tron/security/code-scanning/1](https://github.com/roseteromeo56/java-tron/security/code-scanning/1)

To fix the issue, the error message sent to the user should be sanitized to avoid exposing sensitive information. Instead of including `e.getMessage()` in the response, a generic error message should be used. The exception details can still be logged on the server for debugging purposes.

**Steps to fix:**
1. Replace the error message sent to the user with a generic message, such as `"INVALID address"`.
2. Log the exception details (`e.getMessage()`) on the server using the existing logger (`logger.debug`).
3. Ensure the fix does not alter the existing functionality of the servlet.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
