### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an error message

### DIFF
--- a/framework/src/main/java/org/tron/core/services/http/GetRewardServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/GetRewardServlet.java
@@ -27,15 +27,17 @@ public class GetRewardServlet extends RateLimiterServlet {
       response.getWriter().println("{\"reward\": " + value + "}");
     } catch (DecoderException | IllegalArgumentException e) {
       try {
+        logger.warn("DecoderException or IllegalArgumentException occurred: {}", e.getMessage());
         response.getWriter()
-            .println("{\"Error\": " + "\"INVALID address, " + e.getMessage() + "\"}");
+            .println("{\"Error\": \"INVALID address\"}");
       } catch (IOException ioe) {
         logger.debug("IOException: {}", ioe.getMessage());
       }
     } catch (Exception e) {
       logger.error("", e);
       try {
-        response.getWriter().println(Util.printErrorMsg(e));
+        response.getWriter().println("{\"Error\": \"An unexpected error occurred\"}");
+        logger.error("Unexpected exception occurred: {}", e.getMessage(), e);
       } catch (IOException ioe) {
         logger.debug("IOException: {}", ioe.getMessage());
       }


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/java-tron/security/code-scanning/2](https://github.com/roseteromeo56/java-tron/security/code-scanning/2)

To fix the issue, we will replace the detailed error message sent to the client with a generic error message that does not reveal internal details. The exception details will instead be logged on the server for debugging purposes. Specifically:
1. Replace the response message on line 31 with a generic error message like `"INVALID address"`.
2. Log the exception details (`e.getMessage()`) on the server using the existing logger.

This ensures that sensitive information is not exposed to external users while still allowing developers to debug issues using server logs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
