### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an error message

### DIFF
--- a/framework/src/main/java/org/tron/core/services/http/solidity/GetTransactionByIdSolidityServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/solidity/GetTransactionByIdSolidityServlet.java
@@ -32,7 +32,7 @@ public class GetTransactionByIdSolidityServlet extends RateLimiterServlet {
     } catch (Exception e) {
       logger.debug("Exception: {}", e.getMessage());
       try {
-        response.getWriter().println(e.getMessage());
+        response.getWriter().println("An error occurred while processing the request.");
       } catch (IOException ioe) {
         logger.debug("IOException: {}", ioe.getMessage());
       }
@@ -48,7 +48,7 @@ public class GetTransactionByIdSolidityServlet extends RateLimiterServlet {
     } catch (Exception e) {
       logger.debug("Exception: {}", e.getMessage());
       try {
-        response.getWriter().println(e.getMessage());
+        response.getWriter().println("An error occurred while processing the request.");
       } catch (IOException ioe) {
         logger.debug("IOException: {}", ioe.getMessage());
       }


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/java-tron/security/code-scanning/3](https://github.com/roseteromeo56/java-tron/security/code-scanning/3)

To fix the issue, we will replace the code that writes the exception message (`e.getMessage()`) to the HTTP response with a generic error message. The detailed exception message will be logged internally using the existing `logger.debug` mechanism. This ensures that sensitive information is not exposed to the client while still allowing developers to debug issues using the logs.

Specifically:
1. Replace `response.getWriter().println(e.getMessage());` with a generic error message like `"An error occurred while processing the request."`.
2. Ensure that the detailed exception message is logged internally using `logger.debug`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
