### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through an error message

### DIFF
--- a/framework/src/main/java/org/tron/core/services/http/solidity/GetTransactionInfoByIdSolidityServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/solidity/GetTransactionInfoByIdSolidityServlet.java
@@ -39,7 +39,8 @@ public class GetTransactionInfoByIdSolidityServlet extends RateLimiterServlet {
     } catch (Exception e) {
       logger.debug("Exception: {}", e.getMessage());
       try {
-        response.getWriter().println(e.getMessage());
+        response.getWriter().println("An error occurred while processing your request.");
+        logger.debug("Exception: {}", e.getMessage(), e);
       } catch (IOException ioe) {
         logger.debug("IOException: {}", ioe.getMessage());
       }
@@ -62,7 +63,8 @@ public class GetTransactionInfoByIdSolidityServlet extends RateLimiterServlet {
     } catch (Exception e) {
       logger.debug("Exception: {}", e.getMessage());
       try {
-        response.getWriter().println(e.getMessage());
+        response.getWriter().println("An error occurred while processing your request.");
+        logger.debug("Exception: {}", e.getMessage(), e);
       } catch (IOException ioe) {
         logger.debug("IOException: {}", ioe.getMessage());
       }


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/java-tron/security/code-scanning/4](https://github.com/roseteromeo56/java-tron/security/code-scanning/4)

To fix the issue, the code should be modified to log the exception message internally for debugging purposes while sending a generic error message to the client. This ensures that sensitive information is not exposed to external users. Specifically:

1. Replace `response.getWriter().println(e.getMessage())` with a generic error message like `"An error occurred while processing your request."`.
2. Log the exception message and stack trace using the `logger.debug` method to retain the ability to diagnose issues internally.
3. Ensure that the same approach is applied consistently across both `doGet` and `doPost` methods.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
