### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through an error message

### DIFF
--- a/framework/src/main/java/org/tron/core/services/http/solidity/GetTransactionByIdSolidityServlet.java
+++ b/framework/src/main/java/org/tron/core/services/http/solidity/GetTransactionByIdSolidityServlet.java
@@ -32,7 +32,7 @@ public class GetTransactionByIdSolidityServlet extends RateLimiterServlet {
     } catch (Exception e) {
       logger.debug("Exception: {}", e.getMessage());
       try {
-        response.getWriter().println(e.getMessage());
+        response.getWriter().println("An error occurred while processing the request.");
       } catch (IOException ioe) {
         logger.debug("IOException: {}", ioe.getMessage());
       }
@@ -48,7 +48,7 @@ public class GetTransactionByIdSolidityServlet extends RateLimiterServlet {
     } catch (Exception e) {
       logger.debug("Exception: {}", e.getMessage());
       try {
-        response.getWriter().println(e.getMessage());
+        response.getWriter().println("An error occurred while processing the request.");
       } catch (IOException ioe) {
         logger.debug("IOException: {}", ioe.getMessage());
       }


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/java-tron/security/code-scanning/5](https://github.com/roseteromeo56/java-tron/security/code-scanning/5)

To fix the issue, we will replace the direct exposure of the exception message (`e.getMessage()`) in the HTTP response with a generic error message. The detailed exception message will be logged internally using the existing logger (`logger.debug`) for debugging purposes. This ensures that sensitive information is not exposed to the client while still allowing developers to diagnose issues.

Changes will be made in both the `doGet` and `doPost` methods:
1. Replace `response.getWriter().println(e.getMessage())` with a generic error message like `"An error occurred while processing the request."`.
2. Ensure the detailed exception message is logged internally for debugging.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
