### PR TITLE
Potential fix for code scanning alert no. 7: Implicit narrowing conversion in compound assignment

### DIFF
--- a/actuator/src/main/java/org/tron/core/vm/PrecompiledContracts.java
+++ b/actuator/src/main/java/org/tron/core/vm/PrecompiledContracts.java
@@ -364,7 +364,7 @@ public class PrecompiledContracts {
       s = Arrays.copyOfRange(sign, 32, 64);
       v = sign[64];
       if (v < 27) {
-        v += 27;
+        v = (byte) (v + 27);
       }
 
       SignatureInterface signature = SignUtils.fromComponents(r, s, v,


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/java-tron/security/code-scanning/7](https://github.com/roseteromeo56/java-tron/security/code-scanning/7)

To fix the issue, the compound assignment `v += 27` should be replaced with an explicit addition and cast to ensure that the result is safely converted to `byte`. This avoids the implicit narrowing conversion and makes the code behavior explicit. Specifically, the addition should be performed using `int` arithmetic, and the result should be explicitly cast to `byte` before assigning it back to `v`.

The change will occur in the `recoverAddrBySign` method, specifically on line 367. No additional imports or dependencies are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
