### PR TITLE
Potential fix for code scanning alert no. 8: Implicit narrowing conversion in compound assignment

### DIFF
--- a/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
+++ b/chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java
@@ -460,7 +460,7 @@ public class TransactionCapsule implements ProtoCapsule<Transaction> {
     byte[] s = sign.substring(32, 64).toByteArray();
     byte v = sign.byteAt(64);
     if (v < 27) {
-      v += 27; //revId -> v
+      v = (byte) (v + 27); //revId -> v
     }
     ECDSASignature signature = ECDSASignature.fromComponents(r, s, v);
     return signature.toBase64();


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/java-tron/security/code-scanning/8](https://github.com/roseteromeo56/java-tron/security/code-scanning/8)

To fix the issue, we need to avoid the implicit narrowing conversion by explicitly casting the result of the addition to `byte`. This ensures that the behavior is intentional and avoids potential overflow issues. The fix involves replacing `v += 27` with `v = (byte) (v + 27)`. This makes the narrowing conversion explicit and avoids ambiguity.

**Steps to implement the fix:**
1. Locate the line `v += 27` in the `getBase64FromByteString` method.
2. Replace it with `v = (byte) (v + 27)` to explicitly cast the result of the addition to `byte`.

No additional imports, methods, or definitions are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
