### PR TITLE
Potential fix for code scanning alert no. 9: Implicit narrowing conversion in compound assignment

### DIFF
--- a/chainbase/src/main/java/org/tron/core/service/MortgageService.java
+++ b/chainbase/src/main/java/org/tron/core/service/MortgageService.java
@@ -169,7 +169,7 @@ public class MortgageService {
   }
 
   private long computeReward(long cycle, List<Pair<byte[], Long>> votes) {
-    long reward = 0;
+    double reward = 0;
     for (Pair<byte[], Long> vote : votes) {
       byte[] srAddress = vote.getKey();
       long totalReward = delegationStore.getReward(cycle, srAddress);
@@ -184,7 +184,7 @@ public class MortgageService {
       double voteRate = (double) userVote / totalVote;
       reward += voteRate * totalReward;
     }
-    return reward;
+    return (long) reward;
   }
 
   /**


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/java-tron/security/code-scanning/9](https://github.com/roseteromeo56/java-tron/security/code-scanning/9)

To fix the issue, we need to ensure that the type of the left-hand side (`reward`) is compatible with the type of the right-hand side expression (`voteRate * totalReward`). Since the right-hand side is of type `double`, the best approach is to change the type of `reward` from `long` to `double`. This will preserve the precision of the calculation and avoid the implicit narrowing conversion.

**Steps to implement the fix:**
1. Update the declaration of `reward` on line 172 to use `double` instead of `long`.
2. Ensure that the return type of the `computeReward` method (line 171) remains consistent with the updated type of `reward`. If the method must return a `long`, explicitly cast the final result to `long` before returning, ensuring truncation is intentional.
3. Verify that all usages of `computeReward` handle the updated type correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
