### PR TITLE
Potential fix for code scanning alert no. 10: Implicit narrowing conversion in compound assignment

### DIFF
--- a/framework/src/main/java/org/tron/core/capsule/utils/RLP.java
+++ b/framework/src/main/java/org/tron/core/capsule/utils/RLP.java
@@ -151,7 +151,7 @@ public class RLP {
 
   static short decodeShort(byte[] data, int index) {
 
-    short value = 0;
+    int value = 0;
 
     if (data[index] == 0x00) {
       throw new RuntimeException(NOT_NUM);
@@ -174,7 +174,7 @@ public class RLP {
       // to decode properly into a short.
       throw new RuntimeException(WRONG_DECODE_ATTEMPT);
     }
-    return value;
+    return (short) value;
   }
 
   public static long decodeLong(byte[] data, int index) {


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/java-tron/security/code-scanning/10](https://github.com/roseteromeo56/java-tron/security/code-scanning/10)

To fix the issue, we need to ensure that the type of the left-hand side of the compound assignment (`value`) is at least as wide as the type of the right-hand side expression. The best way to address this is to change the type of `value` from `short` to `int`. This ensures that the result of the bit-shifting operation and the subsequent addition can be safely stored without any risk of overflow or data loss. Since the method is intended to decode a `short`, we can cast the final result back to `short` before returning it.

Changes to be made:
1. Update the declaration of `value` from `short` to `int`.
2. Cast the final result to `short` before returning it.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
