### PR TITLE
Potential fix for code scanning alert no. 11: Implicit narrowing conversion in compound assignment

### DIFF
--- a/framework/src/main/java/org/tron/core/services/jsonrpc/types/TransactionResult.java
+++ b/framework/src/main/java/org/tron/core/services/jsonrpc/types/TransactionResult.java
@@ -70,7 +70,7 @@ public class TransactionResult {
     byte[] sByte = Arrays.copyOfRange(signData, 32, 64);
     byte vByte = signData[64];
     if (vByte < 27) {
-      vByte += 27;
+      vByte = (byte) (vByte + 27);
     }
     v = ByteArray.toJsonHex(vByte);
     r = ByteArray.toJsonHex(rByte);


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/java-tron/security/code-scanning/11](https://github.com/roseteromeo56/java-tron/security/code-scanning/11)

To fix the issue, we need to avoid the implicit narrowing conversion in the compound assignment `vByte += 27`. The best way to address this is to perform the addition explicitly in a way that ensures the result is safely cast back to `byte`. This can be achieved by first performing the addition in the `int` type and then explicitly casting the result to `byte`. This makes the conversion explicit and avoids any ambiguity about the operation.

The specific change involves replacing `vByte += 27;` with `vByte = (byte) (vByte + 27);`. This ensures that the addition is performed in the wider `int` type, and the result is explicitly cast back to `byte`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
