### PR TITLE
Potential fix for code scanning alert no. 12: Implicit narrowing conversion in compound assignment

### DIFF
--- a/framework/src/main/java/org/tron/core/zen/address/SpendingKey.java
+++ b/framework/src/main/java/org/tron/core/zen/address/SpendingKey.java
@@ -89,7 +89,7 @@ public class SpendingKey {
           throw new BadItemException(
               "librustzcash_check_diversifier does not return valid diversifier");
         }
-        blob[33] += 1;
+        blob[33] = (byte) (blob[33] + 1);
       } finally {
         JLibsodium.freeState(state);
       }


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/java-tron/security/code-scanning/12](https://github.com/roseteromeo56/java-tron/security/code-scanning/12)

To fix the issue, the compound assignment `blob[33] += 1` should be replaced with an explicit cast after performing the addition. This ensures that the operation is performed in the wider `int` type and then safely cast back to `byte`. Specifically, the code should be updated to `blob[33] = (byte) (blob[33] + 1)`. This approach avoids implicit narrowing and makes the type conversion explicit, preventing unintended behavior.

No additional imports, methods, or definitions are required to implement this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
