### PR TITLE
Potential fix for code scanning alert no. 13: Implicit narrowing conversion in compound assignment

### DIFF
--- a/framework/src/test/java/org/tron/common/utils/client/utils/TransactionUtils.java
+++ b/framework/src/test/java/org/tron/common/utils/client/utils/TransactionUtils.java
@@ -125,7 +125,7 @@ public class TransactionUtils {
     byte[] s = sign.substring(32, 64).toByteArray();
     byte v = sign.byteAt(64);
     if (v < 27) {
-      v += 27; //revId -> v
+      v = (byte) (v + 27); //revId -> v
     }
     ECDSASignature signature = ECDSASignature.fromComponents(r, s, v);
     return signature.toBase64();


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/java-tron/security/code-scanning/13](https://github.com/roseteromeo56/java-tron/security/code-scanning/13)

To fix the issue, we need to make the conversion explicit by casting the result of the addition to `byte`. This ensures that the behavior is clear and intentional, avoiding any ambiguity about the narrowing conversion. The updated code will replace `v += 27` with `v = (byte) (v + 27)`. This change ensures that the addition is performed as an `int` operation, and the result is explicitly cast back to `byte`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
