### PR TITLE
Fix unsafe command substitution in start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -151,7 +151,7 @@ getLatestReleaseVersion() {
 }
 
 checkVersion() {
- github_release_version=$(`echo getLatestReleaseVersion`)
+ github_release_version=$(getLatestReleaseVersion)
  if [[ -n $github_release_version ]]; then
   echo "info: github latest version: $github_release_version"
   echo $github_release_version
@@ -162,7 +162,7 @@ checkVersion() {
 }
 
 upgrade() {
-  latest_version=$(`echo getLatestReleaseVersion`)
+  latest_version=$(getLatestReleaseVersion)
   echo "info: latest version: $latest_version"
   if [[ -n $latest_version ]]; then
     old_jar="$PWD/$JAR_NAME"
@@ -196,7 +196,7 @@ mkdirFullNode() {
   if [ ! -d $FULL_NODE_DIR ]; then
     echo "info: create $FULL_NODE_DIR"
     mkdir $FULL_NODE_DIR
-    $(cp $0 $FULL_NODE_DIR)
+    cp $0 $FULL_NODE_DIR
     cd $FULL_NODE_DIR
   elif [ -d $FULL_NODE_DIR ]; then
     cd $FULL_NODE_DIR
@@ -204,7 +204,7 @@ mkdirFullNode() {
 }
 
 quickStart() {
-  full_node_version=$(`echo getLatestReleaseVersion`)
+  full_node_version=$(getLatestReleaseVersion)
   if [[ -n $full_node_version ]]; then
     mkdirFullNode
     echo "info: check latest version: $full_node_version"
@@ -280,7 +280,7 @@ stopService() {
 
 checkAllowMemory() {
   os=`uname`
-  totalMemory=$(`echo getTotalMemory`)
+  totalMemory=$(getTotalMemory)
   total=`expr $totalMemory / 1024`
   if [[ $os == 'Darwin' ]]; then
     return
@@ -333,7 +333,7 @@ setJVMMemory() {
       JVM_MX=$(echo "$SPECIFY_MEMORY/1024*0.6" | bc | awk -F. '{print $1"g"}')
       JVM_MS=$JVM_MX
     else
-      total=$(`echo getTotalMemory`)
+      total=$(getTotalMemory)
       MAX_DIRECT_MEMORY=$(echo "$total/1024/1024*0.1" | bc | awk -F. '{print $1"g"}')
       JVM_MX=$(echo "$total/1024/1024*0.6" | bc | awk -F. '{print $1"g"}')
       JVM_MS=$JVM_MX
@@ -383,7 +383,7 @@ rebuildManifest() {
     $JAVACMD -jar $ARCHIVE_JAR -d $REBUILD_DIR -m $REBUILD_MANIFEST_SIZE -b $REBUILD_BATCH_SIZE
   else
     echo 'info: download the rebuild manifest plugin from the github'
-    local latest=$(`echo getLatestReleaseVersion`)
+    local latest=$(getLatestReleaseVersion)
     download $RELEASE_URL/download/GreatVoyage-v"$latest"/$ARCHIVE_JAR $ARCHIVE_JAR
     if [[ $download == 0 ]]; then
       echo 'info: download success, rebuild manifest'
@@ -428,7 +428,7 @@ specifyConfig(){
 
 checkSign() {
   echo 'info: verify signature'
-  local latest_version=$(`echo getLatestReleaseVersion`)
+  local latest_version=$(getLatestReleaseVersion)
   download $RELEASE_URL/download/$latest_version/sha256sum.txt sha256sum.txt
   fullNodeSha256=$(cat sha256sum.txt|grep 'FullNode'| awk -F ' ' '{print $1}')
 
@@ -603,7 +603,7 @@ if [[ $UPGRADE == true ]]; then
 fi
 
 if [[ $DOWNLOAD == true ]]; then
-  latest=$(`echo getLatestReleaseVersion`)
+  latest=$(getLatestReleaseVersion)
   if [[ -n $latest ]]; then
     download $RELEASE_URL/download/$latest/$JAR_NAME $latest
     exit


### PR DESCRIPTION
<!-- dd-meta {"pullId":"3846b84f-bba4-4a29-9aad-abe2f239027a","source":"chat","resourceId":"b9fd215b-f60a-4dfe-81cb-960fbfa9b7a4","workflowId":"86fe0b6b-e404-4ebb-81b7-1951e463cb4f","codeChangeId":"86fe0b6b-e404-4ebb-81b7-1951e463cb4f","sourceType":"code_security_sast"} -->
Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/e8b420c429e4c0b2e0cb731e4d1758a3?panel_event_id=AwAAAZ8dhSpCTz9YLAAAABhBWjhkaFNwQ0FBQ1dtM0VRU1JfWlZGNEwAAAAkZjE5ZjFkOGMtZTE2NC00NDBjLTg0ZTItYTMwOTRkMTU0MDMzAAAW_w&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZThiNDIwYzQyOWU0YzBiMmUwY2I3MzFlNGQxNzU4YTN-NjExZDU0MWQ1MmU2ZWQ5Y2UzZTVhZmUxNzgyOTk2MWQ%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fjava-tron%22+%22Do+not+use+%24%28...%29+to+run+commands.+Run+the+inner+command+directly%2C+or+use+eval+with+a+quoted+string+%28and+careful+escaping%29+only+when+you+intentionally+execute+shell+code+produced+as+text.%22)

**What does this PR do?**
- Replaces unsafe command-substitution execution patterns in `start.sh` with direct function invocation using `$(function_name)`.
- Removes command substitution used to run `cp` in `mkdirFullNode`, executing `cp` directly instead.
- Applies the same safe invocation pattern consistently to all matching occurrences in `start.sh` to avoid repeat findings for the same root issue.

**Why are these changes required?**
- The current pattern executes shell code produced as text (for example, ``$(`echo getTotalMemory`)``), which is flagged by SAST as a critical command-execution risk.
- Calling functions directly removes unnecessary dynamic execution behavior and aligns with secure shell scripting practices.

**This PR has been tested by:**
- Unit Tests
  - Not applicable for this shell-script-only change.
- Manual Testing
  - `bash -n start.sh` (syntax check passed)
  - Verified no remaining `$(\`echo ...)` execution pattern in `start.sh`.

**Follow up**
- None.

**Extra details**
- Addresses SAST finding rule: `bash-security/dont-execute-command-substitution-output` in `start.sh`.
- Includes the originally reported location at line 336 and additional occurrences of the same anti-pattern in the same script.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/b9fd215b-f60a-4dfe-81cb-960fbfa9b7a4)

Comment @datadog to request changes