### PR TITLE
Fix unsafe command invocation in start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -333,7 +333,7 @@ setJVMMemory() {
       JVM_MX=$(echo "$SPECIFY_MEMORY/1024*0.6" | bc | awk -F. '{print $1"g"}')
       JVM_MS=$JVM_MX
     else
-      total=$(`echo getTotalMemory`)
+      total=$(getTotalMemory)
       MAX_DIRECT_MEMORY=$(echo "$total/1024/1024*0.1" | bc | awk -F. '{print $1"g"}')
       JVM_MX=$(echo "$total/1024/1024*0.6" | bc | awk -F. '{print $1"g"}')
       JVM_MS=$JVM_MX


### PR DESCRIPTION
<!-- dd-meta {"pullId":"1be48d1d-29b0-4e0b-b84b-58011e0eddc3","source":"chat","resourceId":"b6069f67-1802-487c-a5f5-d37383d638f3","workflowId":"7f01945d-c168-4bf6-9a87-b3178e186d17","codeChangeId":"7f01945d-c168-4bf6-9a87-b3178e186d17","sourceType":"code_security_sast"} -->
Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/e8b420c429e4c0b2e0cb731e4d1758a3?query=%40status%3Aopen%20-%40vulnerability.confidence%3Alow&column=score&order=desc&panel_event_id=AwAAAZ8dhSpCTz9YLAAAABhBWjhkaFNwQ0FBQ1dtM0VRU1JfWlZGNEwAAAAkZjE5ZjFkOGMtZTE2NC00YjkwLTg1OTItMmQxYTNiMjYyZDJlAAAW_w)

**What does this PR do?**
- Replaces unsafe command-name command substitution at `start.sh` line 336 with a direct function invocation and output capture.
- Changes `total=$(`echo getTotalMemory`)` to `total=$(getTotalMemory)`.

**Why are these changes required?**
- The previous pattern executes the output text from a nested command as a command name, which is unsafe and can lead to command execution risks (CWE-78).
- Directly invoking `getTotalMemory` is the idiomatic and robust shell approach for this logic.

**This PR has been tested by:**
- Unit Tests
  - Not applicable (shell script change).
- Manual Testing
  - Ran `bash -n start.sh` to validate script syntax.
  - Verified the updated line in context and confirmed only the intended security fix was applied.

**Follow up**
- None.

**Extra details**
- Scope is intentionally limited to the flagged vulnerability location only.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/b6069f67-1802-487c-a5f5-d37383d638f3)

Comment @datadog to request changes